### PR TITLE
Update Working with Templates section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ template = SendGrid::Template.new('MY_TEMPLATE_ID')
 Create a `Client`
 
 ```ruby
-client = SendGrid::Client.new(api_user: my_user, api_key: my_key)
+client = SendGrid::Client.new(api_key: my_key)
 ```
 
 Initialize mail defaults and create the `TemplateMailer`


### PR DESCRIPTION
The example code for creating a client in this section uses a 2-argument constructor, but the arguments are *api_user* and *api_key*:
```
client = SendGrid::Client.new(api_user: my_user, api_key: my_key)
```
The 2-argument constructor (if used) should should be the *api_user* and *api-password*, but it would be preferable to use the 1-arg constructor with the *api_key* instead:

```
client = SendGrid::Client.new(api_key: my_key)
```